### PR TITLE
Fix bug about the "elseif" stmt

### DIFF
--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -339,7 +339,6 @@ class Parser {
 
         if ($node instanceof Node\Stmt\If_) {
             foreach ($node->elseifs as $elseIf) {
-               // $this->parseIf($elseIf);
                 $this->parseElseIf($elseIf, $endBlock);
             }
             if ($node->else) {
@@ -369,7 +368,6 @@ class Parser {
 
         $this->block->children[] = new Op\Stmt\Jump($targetNode, $attrs);
         $targetNode->addParent($this->block);
-        //$endBlock->addParent($this->block);
 
         $this->block = $elseBlock;
 

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -339,12 +339,40 @@ class Parser {
 
         if ($node instanceof Node\Stmt\If_) {
             foreach ($node->elseifs as $elseIf) {
-                $this->parseIf($elseIf);
+               // $this->parseIf($elseIf);
+                $this->parseElseIf($elseIf, $endBlock);
             }
             if ($node->else) {
                 $this->block = $this->parseNodes($node->else->stmts, $this->block);
             }
         }
+        $this->block->children[] = new Op\Stmt\Jump($endBlock, $attrs);
+        $endBlock->addParent($this->block);
+        $this->block = $endBlock;
+    }
+
+    protected function parseElseIf($node, $targetNode){
+        $attrs = $this->mapAttributes($node);
+        $cond = $this->readVariable($this->parseExprNode($node->cond));
+        $ifBlock = new Block;
+        $elseBlock = new Block;
+        $endBlock = new Block;
+
+        $this->block->children[] = new Op\Stmt\JumpIf($cond, $ifBlock, $elseBlock, $attrs);
+        $this->processAssertions($cond, $ifBlock, $elseBlock);
+        $ifBlock->addParent($this->block);
+        $elseBlock->addParent($this->block);
+
+        $this->block = $ifBlock;
+        
+        $this->block = $this->parseNodes($node->stmts, $ifBlock);
+
+        $this->block->children[] = new Op\Stmt\Jump($targetNode, $attrs);
+        $targetNode->addParent($this->block);
+        //$endBlock->addParent($this->block);
+
+        $this->block = $elseBlock;
+
         $this->block->children[] = new Op\Stmt\Jump($endBlock, $attrs);
         $endBlock->addParent($this->block);
         $this->block = $endBlock;


### PR DESCRIPTION
I think that  "elseif" should not be treated as "Stmt\If_", the target line should point to the endblock.
before I modified:
![2015-09-08 12 26 59](https://cloud.githubusercontent.com/assets/3403235/9720423/7b0d6b14-55c0-11e5-87ab-bf22effb1d2d.png)
after changing the parse.php file:
![2015-09-08 12 27 16](https://cloud.githubusercontent.com/assets/3403235/9720450/c5597a1e-55c0-11e5-9d69-e8d3ebbbdd61.png)


 