### PR TITLE
Proof of Concept for exception flow with finally's

### DIFF
--- a/lib/PHPCfg/Func.php
+++ b/lib/PHPCfg/Func.php
@@ -22,6 +22,10 @@ class Func {
     public $params;
     /** @var Block|null */
     public $cfg;
+    /** @var  Block */
+    public $stopNormal;
+    /** @var  Block */
+    public $stopException;
 
     public function __construct($name, $returnsRef, $returnType, $class) {
         $this->name = $name;
@@ -30,6 +34,8 @@ class Func {
         $this->class = $class;
         $this->params = [];
         $this->cfg = new Block;
+        $this->stopNormal = new Block;
+        $this->stopException = new Block;
     }
 
     public function getScopedName() {

--- a/lib/PHPCfg/Op/Exception/Current.php
+++ b/lib/PHPCfg/Op/Exception/Current.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PHPCfg\Op\Exception;
+
+use PHPCfg\Op\Expr;
+use PHPCfg\Operand;
+
+class Current extends Expr {
+	public $var;
+
+	public function __construct(array $attributes = []) {
+		parent::__construct($attributes);
+	}
+
+	public function getVariableNames() {
+		return ['result'];
+	}
+}

--- a/lib/PHPCfg/Op/Exception/Recover.php
+++ b/lib/PHPCfg/Op/Exception/Recover.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PHPCfg\Op\Exception;
+
+use PHPCfg\Op\Terminal;
+use PHPCfg\Operand;
+
+class Recover extends Terminal {
+	public function __construct(array $attributes = []) {
+		parent::__construct($attributes);
+	}
+
+	public function getVariableNames() {
+		return [];
+	}
+}

--- a/lib/PHPCfg/Op/Exception/Throw_.php
+++ b/lib/PHPCfg/Op/Exception/Throw_.php
@@ -7,7 +7,7 @@
  * @license MIT See LICENSE at the root of the project for more info
  */
 
-namespace PHPCfg\Op\Terminal;
+namespace PHPCfg\Op\Exception;
 
 use PHPCfg\Op\Terminal;
 use PHPCfg\Operand;
@@ -23,9 +23,4 @@ class Throw_ extends Terminal {
     public function getVariableNames() {
         return ['expr'];
     }
-
-    public function getSubBlocks() {
-        return [];
-    }
-
 }


### PR DESCRIPTION
I was hoping you could take a look at this, it's not meant to be merged in its current form. If we can come to some concencus about 
how this should work then I will add a lot of tests for weird edge cases before merging.

This change implements control flow for try-catch-finally constructs. It only takes explicitly thrown exceptions into account, and does not 
(yet?) support exceptions thrown in method/function calls. I also implemented the finally's for goto & return.

The finally's were actually a big pain to get working, but I think I got there now. The idea is that we inline finally code in every possible 
path that can go through it. This is apparently how the JVM does it since 1.6. I guess it could be possible to do it without inlining, but that
would require some kind of subroutine or weird jumping logic at the end of a finally block. 

I added some Ops for dealing specifically with the current exception. They assume the exception gets stored in some globally available 
location, and does not use a variable. But maybe some other types of Ops could be more suited?

Any feedback/comments would be much appreciated. 