### PR TITLE
improved_call_finder

### DIFF
--- a/lib/PHPCfg/Func.php
+++ b/lib/PHPCfg/Func.php
@@ -9,6 +9,8 @@
 
 namespace PHPCfg;
 
+use PHPCfg\Op\CallableOp;
+
 class Func {
     /* Constants for the $flags property.
      * The first six flags match PhpParser Class_ flags. */
@@ -33,6 +35,8 @@ class Func {
     public $params;
     /** @var Block|null */
     public $cfg;
+    /** @var CallableOp|null */
+    public $callable_op;
 
     public function __construct($name, $flags, $returnType, $class) {
         $this->name = $name;

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -193,7 +193,8 @@ class Parser {
             $func->cfg = null;
         }
 
-        $this->block->children[] = new Op\Stmt\ClassMethod($func, $this->mapAttributes($node));
+        $this->block->children[] = $class_method = new Op\Stmt\ClassMethod($func, $this->mapAttributes($node));
+        $func->callable_op = $class_method;
     }
 
     protected function parseStmt_Const(Stmt\Const_ $node) {
@@ -317,7 +318,8 @@ class Parser {
             null
         );
         $this->parseFunc($func, $node->params, $node->stmts, null);
-        $this->block->children[] = new Op\Stmt\Function_($func, $this->mapAttributes($node));
+        $this->block->children[] = $function = new Op\Stmt\Function_($func, $this->mapAttributes($node));
+        $func->callable_op = $function;
     }
 
     protected function parseStmt_Global(Stmt\Global_ $node) {
@@ -872,7 +874,9 @@ class Parser {
         );
         $this->parseFunc($func, $expr->params, $expr->stmts, null);
 
-        return new Op\Expr\Closure($func, $uses, $this->mapAttributes($expr));
+        $closure = new Op\Expr\Closure($func, $uses, $this->mapAttributes($expr));
+        $func->callable_op = $closure;
+        return $closure;
     }
 
     protected function parseExpr_ClassConstFetch(Expr\ClassConstFetch $expr) {

--- a/lib/PHPCfg/Visitor/CallFinder.php
+++ b/lib/PHPCfg/Visitor/CallFinder.php
@@ -10,33 +10,65 @@
 namespace PHPCfg\Visitor;
 
 use PHPCfg\Block;
+use PHPCfg\Func;
 use PHPCfg\Op;
 use PHPCfg\Operand;
 use PHPCfg\AbstractVisitor;
 
 class CallFinder extends AbstractVisitor {
-    
-    protected $calls = [];
+    /** @var Func[] */
     protected $funcStack = [];
+    /** @var Func */
     protected $func;
+    /** @var Op\Expr\FuncCall[] */
+    protected $funcCalls = [];
+    /** @var Op\Expr\NsFuncCall[] */
+    protected $nsFuncCalls = [];
+    /** @var Op\Expr\MethodCall[] */
+    protected $methodCalls = [];
+    /** @var Op\Expr\New_[] */
+    protected $newCalls = [];
 
-    public function getCallsForFunction($func) {
-        $func = strtolower($func);
-        return isset($this->calls[$func]) ? $this->calls[$func] : [];
+    /**
+     * @return Op\Expr\New_[]
+     */
+    public function getNewCalls() {
+        return $this->newCalls;
+    }
+
+    /**
+     * @return Op\Expr\MethodCall[]
+     */
+    public function getMethodCalls() {
+        return $this->methodCalls;
+    }
+
+    /**
+     * @return Op\Expr\NsFuncCall[]
+     */
+    public function getNsFuncCalls() {
+        return $this->nsFuncCalls;
+    }
+
+    /**
+     * @return Op\Expr\FuncCall[]
+     */
+    public function getFuncCalls() {
+        return $this->funcCalls;
     }
 
     public function enterOp(Op $op, Block $block) {
         if ($op instanceof Op\CallableOp) {
             $this->funcStack[] = $this->func;
             $this->func = $op;
-        }
-        if ($op instanceof Op\Expr\FuncCall) {
-            if ($op->name instanceof Operand\Literal) {
-                $this->calls[strtolower($op->name->value)][] = [
-                    $op,
-                    $this->func
-                ];
-            }
+        } elseif ($op instanceof Op\Expr\FuncCall) {
+            $this->funcCalls[] = [$op, $this->func];
+        } elseif ($op instanceof Op\Expr\NsFuncCall) {
+            $this->nsFuncCalls[] = [$op, $this->func];
+        } elseif ($op instanceof Op\Expr\MethodCall) {
+            $this->methodCalls[] = [$op, $this->func];
+        } elseif ($op instanceof Op\Expr\New_) {
+            $this->newCalls[] = [$op, $this->func];
         }
     }
 
@@ -45,5 +77,4 @@ class CallFinder extends AbstractVisitor {
             $this->func = array_pop($this->funcStack);
         }
     }
-
 }


### PR DESCRIPTION
1) Improved callfinder.
2) Backreference from Func to callable op, analogous to the one from Param to Func. Like the existing back reference, this allows php-types to parse the doccomment for @param declarations