### PR TITLE
NameResolver soft fail for invalid doc comments

### DIFF
--- a/lib/PHPCfg/AstVisitor/NameResolver.php
+++ b/lib/PHPCfg/AstVisitor/NameResolver.php
@@ -49,10 +49,7 @@ class NameResolver extends NameResolverParent {
                 preg_replace_callback(
                     $regex,
                     function ($match) {
-                        $type = $match[2];
-                        if (($new_type = $this->parseTypeDecl($type)) !== false) {
-                            $type = $new_type;
-                        }
+                        $type = $this->parseTypeDecl($match[2]);
                         return "@{$match[1]} {$type}";
                     },
                     $comment->getText()
@@ -84,7 +81,7 @@ class NameResolver extends NameResolverParent {
         }
         $regex = '(^([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$)';
         if (!preg_match($regex, $type)) {
-            return false;
+            return $type;   // malformed Type, return original string
         }
         if (in_array(strtolower($type), self::$builtInTypes)) {
             return $type;

--- a/lib/PHPCfg/AstVisitor/NameResolver.php
+++ b/lib/PHPCfg/AstVisitor/NameResolver.php
@@ -44,12 +44,15 @@ class NameResolver extends NameResolverParent {
         parent::enterNode($node);
         $comment = $node->getDocComment();
         if ($comment) {
-            $regex = "(@(param|return|var|type)\s+(\S+))";
+            $regex = "(@(param|return|var|type)\h+(\S+))";
             $comment->setText(
                 preg_replace_callback(
                     $regex,
                     function ($match) {
-                        $type = $this->parseTypeDecl($match[2]);
+                        $type = $match[2];
+                        if (($new_type = $this->parseTypeDecl($type)) !== false) {
+                            $type = $new_type;
+                        }
                         return "@{$match[1]} {$type}";
                     },
                     $comment->getText()
@@ -81,7 +84,7 @@ class NameResolver extends NameResolverParent {
         }
         $regex = '(^([a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*\\\\)*[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*$)';
         if (!preg_match($regex, $type)) {
-            throw new \RuntimeException("Unknown type declaration found: $type");
+            return false;
         }
         if (in_array(strtolower($type), self::$builtInTypes)) {
             return $type;

--- a/test/PHPCfg/NameResolverTest.php
+++ b/test/PHPCfg/NameResolverTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace PHPCfg;
+
+use PHPCfg\AstVisitor\NameResolver;
+use PhpParser\NodeTraverser;
+use PhpParser\Parser;
+use PhpParser\ParserFactory;
+
+class NameResolverTest extends \PHPUnit_Framework_TestCase {
+	/** @var  Parser */
+	private $astParser;
+
+	protected function setUp() {
+		$this->astParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
+	}
+
+	/** @dataProvider getIgnoresInvalidParamTypeInDocCommentCases */
+	public function testIgnoresInvalidParamTypeInDocComment($type) {
+		$doccomment = <<< EOF
+/**
+ * @param $type \$a
+ */
+EOF;
+		$code = <<< EOF
+<?php
+$doccomment
+function foo(\$a) {}
+EOF;
+		$ast = $this->astParser->parse($code);
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor(new NameResolver());
+		$traverser->traverse($ast);
+		$this->assertEquals($doccomment, $ast[0]->getDocComment()->getText());
+	}
+
+	public function getIgnoresInvalidParamTypeInDocCommentCases() {
+		return [
+			['123'],
+			['*'],
+			['[]'],
+			['$b'],
+			['@param'],
+		];
+	}
+
+	public function testFullyQualifiesClassInDocComment() {
+		$formatString = <<< EOF
+/**
+ * @param %s \$bar
+ */
+EOF;
+		$original = sprintf($formatString, 'Bar');
+		$expected = sprintf($formatString, 'Foo\\Bar');
+		$code = <<< EOF
+<?php
+namespace Foo {
+	class Bar {}
+}
+
+namespace {
+	use Foo\Bar;
+	
+	$original
+	function baz(Bar \$bar) {}
+}
+EOF;
+
+		$ast = $this->astParser->parse($code);
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor(new NameResolver());
+		$traverser->traverse($ast);
+		$actual = $ast[1]->stmts[1]->getDocComment()->getText();
+		$this->assertEquals($expected, $actual);
+	}
+
+	public function testFullyQualifiesClassAliasInDocComment() {
+		$formatString = <<< EOF
+/**
+ * @param %s \$bar
+ */
+EOF;
+		$original = sprintf($formatString, 'Quux');
+		$expected = sprintf($formatString, 'Foo\\Bar');
+		$code = <<< EOF
+<?php
+namespace Foo {
+	class Bar {}
+}
+
+namespace {
+	use Foo\Bar as Quux;
+	
+	$original
+	function baz(Quux \$bar) {}
+}
+EOF;
+
+		$ast = $this->astParser->parse($code);
+		$traverser = new NodeTraverser();
+		$traverser->addVisitor(new NameResolver());
+		$traverser->traverse($ast);
+		$actual = $ast[1]->stmts[1]->getDocComment()->getText();
+		$this->assertEquals($expected, $actual);
+	}
+}


### PR DESCRIPTION
implemented soft fail for type rewriting in doc comments - too many real life doc comments are not valid, so ignoring them would be better