### PR TITLE
Fixed parents for blocks from Expr\ErrorSuppress

### DIFF
--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -925,10 +925,12 @@ class Parser {
         $attrs = $this->mapAttributes($expr);
         $block = new ErrorSuppressBlock;
         $this->block->children[] = new Jump($block, $attrs);
+        $block->addParent($this->block);
         $this->block = $block;
         $result = $this->parseExprNode($expr->expr);
         $end = new Block;
         $this->block->children[] = new Jump($end, $attrs);
+        $end->addParent($this->block);
         $this->block = $end;
         return $result;
     }


### PR DESCRIPTION
I encountered a bug where the Parser was not correctly resolving a
variable when I used an error suppress expression. I fixed this by
adding a parent to each of the two blocks introduced in
parseExpr_ErrorSuppress. The parent in each case is the block that just
added a Jump to the new block.

A parent for the block was eventually being added by the Simplifier
visitor, but this was not in time for variable resolution.

I have attached the test program I used to demonstrate the error, small_test.php.txt. I have also attached the output running "php demo.php small_test.php" with the upstream version of php-cfg in incorrect_output.txt, and the output from running that command with my modifications.
All tests continue to pass.
[correct_output.txt](https://github.com/ircmaxell/php-cfg/files/1560966/correct_output.txt)
[incorrect_output.txt](https://github.com/ircmaxell/php-cfg/files/1560967/incorrect_output.txt)
[small_test.php.txt](https://github.com/ircmaxell/php-cfg/files/1560975/small_test.php.txt)



