### PR TITLE
Fix method name

### DIFF
--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -192,7 +192,7 @@ class Parser {
         }
 
         $this->script->functions[] = $func = new Func(
-            $node->name,
+            $node->name->toString(),
             $node->flags | ($node->byRef ? Func::FLAG_RETURNS_REF : 0),
             $this->parseExprNode($node->returnType),
             $this->currentClass


### PR DESCRIPTION
Hello,
It's expected that the type of the **name** property of **PHPCFG\Func** be a string,
but the parser for the methods assigns an object of type Node\Identifier.
This pull request fix it with the use of `toString()` method.

Eric