### PR TITLE
support of php and phpunit version 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 7.4snapshot
+  - 8.0snapshot
   - nightly
 
 install:

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "phpdocumentor/graphviz": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^8.0 || ^9.0",
 		"friendsofphp/php-cs-fixer": "*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,12 @@
         }
     ],
     "require": {
-        "php": "^7.4",
+        "php": ">=7.4",
         "nikic/php-parser": "^4.0",
         "phpdocumentor/graphviz": "^1.0.4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0",
 		"friendsofphp/php-cs-fixer": "*"
     },
     "autoload": {

--- a/lib/PHPCfg/Op/Type/MixedType.php
+++ b/lib/PHPCfg/Op/Type/MixedType.php
@@ -14,6 +14,6 @@ namespace PHPCfg\Op\Type;
 use PHPCfg\Block;
 use PHPCfg\Op\Type;
 
-class Mixed extends Type
+class MixedType extends Type
 {
 }

--- a/lib/PHPCfg/Op/Type/Mixed_.php
+++ b/lib/PHPCfg/Op/Type/Mixed_.php
@@ -14,6 +14,6 @@ namespace PHPCfg\Op\Type;
 use PHPCfg\Block;
 use PHPCfg\Op\Type;
 
-class MixedType extends Type
+class Mixed_ extends Type
 {
 }

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -172,7 +172,7 @@ class Parser
 
     protected function parseTypeNode(?Node $node): Op\Type {
         if (is_null($node)) {
-            return new Op\Type\Mixed;
+            return new Op\Type\MixedType;
         }
         if ($node instanceof Node\Name) {
             return new Op\Type\Reference(

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -172,7 +172,7 @@ class Parser
 
     protected function parseTypeNode(?Node $node): Op\Type {
         if (is_null($node)) {
-            return new Op\Type\MixedType;
+            return new Op\Type\Mixed_;
         }
         if ($node instanceof Node\Name) {
             return new Op\Type\Reference(

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -245,7 +245,7 @@ abstract class Printer
     }
 
     protected function renderType(?Op\Type $type): string {
-        if ($type instanceof Op\Type\Mixed) {
+        if ($type instanceof Op\Type\MixedType) {
             return 'mixed';
         }
         if ($type instanceof Op\Type\Void_) {

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -245,7 +245,7 @@ abstract class Printer
     }
 
     protected function renderType(?Op\Type $type): string {
-        if ($type instanceof Op\Type\MixedType) {
+        if ($type instanceof Op\Type\Mixed_) {
             return 'mixed';
         }
         if ($type instanceof Op\Type\Void_) {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,23 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
-         colors="false"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         processIsolation="false"
-         stopOnFailure="false"
-         bootstrap="./vendor/autoload.php">
-    <testsuites>
-        <testsuite name="PHPCfg Test Suite">
-            <directory>./test/</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">./lib/PHPCfg/</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage>
+    <include>
+      <directory suffix=".php">./lib/PHPCfg/</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="PHPCfg Test Suite">
+      <directory>./test/</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" backupGlobals="false" backupStaticAttributes="false" colors="false" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" bootstrap="./vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">./lib/PHPCfg/</directory>
-    </include>
-  </coverage>
-  <testsuites>
-    <testsuite name="PHPCfg Test Suite">
-      <directory>./test/</directory>
-    </testsuite>
-  </testsuites>
+
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         colors="false"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         bootstrap="./vendor/autoload.php">
+    <testsuites>
+        <testsuite name="PHPCfg Test Suite">
+            <directory>./test/</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist>
+            <directory suffix=".php">./lib/PHPCfg/</directory>
+        </whitelist>
+    </filter>
 </phpunit>

--- a/test/PHPCfg/NameResolverTest.php
+++ b/test/PHPCfg/NameResolverTest.php
@@ -22,7 +22,7 @@ class NameResolverTest extends TestCase
     /** @var Parser */
     private $astParser;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->astParser = (new ParserFactory())->create(ParserFactory::PREFER_PHP7);
     }


### PR DESCRIPTION
Add support of php8:

* and fix this error: `PHP Fatal error:  Cannot use 'Mixed' as class name as it is reserved in ./php-cfg/lib/PHPCfg/Op/Type/Mixed.php on line 17`

upgrade phpunit to version 8 [which introduces](https://phpunit.de/announcements/phpunit-8.html) `void` return type declaration: 
* and fix this error: `PHP Fatal error:  Declaration of PHPCfg\NameResolverTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in ./php-cfg/test/PHPCfg/NameResolverTest.php on line 25`
