### PR TITLE
handle union type

### DIFF
--- a/lib/PHPCfg/Op/Type/Union.php
+++ b/lib/PHPCfg/Op/Type/Union.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of PHP-CFG, a Control flow graph implementation for PHP
+ *
+ * @copyright 2015 Anthony Ferrara. All rights reserved
+ * @license MIT See LICENSE at the root of the project for more info
+ */
+
+namespace PHPCfg\Op\Type;
+
+use PHPCfg\Block;
+use PHPCfg\Op\Type;
+
+class Union extends Type
+{
+    public array $subtypes;
+
+    public function __construct(array $subtypes, array $attributes = []) {
+        $this->subtypes = $subtypes;
+    }
+
+    public function getVariableNames(): array
+    {
+        return ['subtypes'];
+    }
+} 

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -186,6 +186,17 @@ class Parser
                 $this->mapAttributes($node)
             );
         }
+        if ($node instanceof Node\UnionType) {
+            $parsedTypes = [];
+            foreach($node->types as $type) {
+              $parsedTypes[] = $this->parseTypeNode($type);
+            }
+            
+            return new Op\Type\Union(
+                $parsedTypes,
+                $this->mapAttributes($node)
+            );
+        }
         if ($node instanceof Node\Identifier) {
             return new Op\Type\Literal(
                 $node->name,

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -254,6 +254,18 @@ abstract class Printer
         if ($type instanceof Op\Type\Nullable) {
             return '?' . $this->renderType($type->subtype);
         }
+        if ($type instanceof Op\Type\Union) {
+            $i = 1;
+            $strTypes = "";
+            foreach($type->subtypes as $subtype) {
+              $strTypes .= $this->renderType($subtype);
+              if($i < count($type->subtypes)) {
+                $strTypes .= "|";
+              }
+              $i ++;
+            }
+            return $strTypes;
+        }
         if ($type instanceof Op\Type\Reference) {
             return $this->renderOperand($type->declaration);
         }

--- a/test/code/unionType.test
+++ b/test/code/unionType.test
@@ -1,0 +1,17 @@
+<?php
+function foo(array|string|null $string) {
+
+}
+-----
+Block#1
+    Stmt_Function<foo>
+    Terminal_Return
+
+Function foo(): mixed
+Block#1
+    Expr_Param
+        declaredType: array|string|null
+        name: LITERAL('string')
+        result: Var#1<$string>
+    Terminal_Return
+


### PR DESCRIPTION
A PR to try to handle union type.

Today when parsing this code:
```
function foo(array|string|null $string) {

}
```
an exception is raised:
```
LogicException: Unknown type node: UnionType in /php-cfg/lib/PHPCfg/Parser.php:195

```