### PR TITLE
add indication about loops

### DIFF
--- a/lib/PHPCfg/Op/Stmt/JumpIf.php
+++ b/lib/PHPCfg/Op/Stmt/JumpIf.php
@@ -23,12 +23,15 @@ class JumpIf extends Stmt
 
     public Block $else;
 
-    public function __construct(Operand $cond, Block $if, Block $else, array $attributes = [])
+    public bool $fromLoop;
+
+    public function __construct(Operand $cond, Block $if, Block $else, bool $fromLoop, array $attributes = [])
     {
         parent::__construct($attributes);
         $this->if = $if;
         $this->else = $else;
         $this->cond = $this->addReadRef($cond);
+        $this->fromLoop = $fromLoop;
     }
 
     public function getVariableNames(): array

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -316,7 +316,7 @@ class Parser
         $this->block = $loopBody;
         $this->block = $this->parseNodes($node->stmts, $loopBody);
         $cond = $this->readVariable($this->parseExprNode($node->cond));
-        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, $this->mapAttributes($node));
+        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, true, $this->mapAttributes($node));
         $this->processAssertions($cond, $loopBody, $loopEnd);
         $loopBody->addParent($this->block);
         $loopEnd->addParent($this->block);
@@ -348,7 +348,7 @@ class Parser
         } else {
             $cond = new Literal(true);
         }
-        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, $this->mapAttributes($node));
+        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, true, $this->mapAttributes($node));
         $this->processAssertions($cond, $loopBody, $loopEnd);
         $loopBody->addParent($this->block);
         $loopEnd->addParent($this->block);
@@ -374,7 +374,7 @@ class Parser
         $loopInit->addParent($this->block);
 
         $loopInit->children[] = $validOp = new Op\Iterator\Valid($iterable, $attrs);
-        $loopInit->children[] = new JumpIf($validOp->result, $loopBody, $loopEnd, $attrs);
+        $loopInit->children[] = new JumpIf($validOp->result, $loopBody, $loopEnd, true, $attrs);
         $this->processAssertions($validOp->result, $loopBody, $loopEnd);
         $loopBody->addParent($loopInit);
         $loopEnd->addParent($loopInit);
@@ -472,7 +472,7 @@ class Parser
         $ifBlock = new Block($this->block);
         $elseBlock = new Block($this->block);
 
-        $this->block->children[] = new JumpIf($cond, $ifBlock, $elseBlock, $attrs);
+        $this->block->children[] = new JumpIf($cond, $ifBlock, $elseBlock, false, $attrs);
         $this->processAssertions($cond, $ifBlock, $elseBlock);
 
         $this->block = $this->parseNodes($node->stmts, $ifBlock);
@@ -638,7 +638,7 @@ class Parser
                 );
 
                 $elseBlock = new Block();
-                $this->block->children[] = new JumpIf($cmp->result, $ifBlock, $elseBlock);
+                $this->block->children[] = new JumpIf($cmp->result, $ifBlock, $elseBlock, false);
                 $ifBlock->addParent($this->block);
                 $elseBlock->addParent($this->block);
                 $this->block = $elseBlock;
@@ -715,7 +715,7 @@ class Parser
         $this->block = $loopInit;
         $cond = $this->readVariable($this->parseExprNode($node->cond));
 
-        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, $this->mapAttributes($node));
+        $this->block->children[] = new JumpIf($cond, $loopBody, $loopEnd, true, $this->mapAttributes($node));
         $this->processAssertions($cond, $loopBody, $loopEnd);
         $loopBody->addParent($this->block);
         $loopEnd->addParent($this->block);
@@ -1290,7 +1290,7 @@ class Parser
         $ifBlock = $this->block->create();
         $elseBlock = $this->block->create();
         $endBlock = $this->block->create();
-        $this->block->children[] = new JumpIf($cond, $ifBlock, $elseBlock, $attrs);
+        $this->block->children[] = new JumpIf($cond, $ifBlock, $elseBlock, false, $attrs);
         $this->processAssertions($cond, $ifBlock, $elseBlock);
         $ifBlock->addParent($this->block);
         $elseBlock->addParent($this->block);
@@ -1537,7 +1537,7 @@ class Parser
         $if = $isOr ? $endBlock : $longBlock;
         $else = $isOr ? $longBlock : $endBlock;
 
-        $this->block->children[] = new JumpIf($left, $if, $else);
+        $this->block->children[] = new JumpIf($left, $if, $else, false);
         $longBlock->addParent($this->block);
         $endBlock->addParent($this->block);
 

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -123,6 +123,9 @@ abstract class Printer
             $result .= "\n    flags: " . $this->indent($this->renderFlags($op));
             $result .= "\n    declaredType: " . $this->indent($this->renderType($op->declaredType));
         }
+        if ($op instanceof Op\Stmt\JumpIf) {
+            $result .= "\n    from_loop: " . var_export($op->fromLoop, true);
+        }
         if ($op instanceof Op\Stmt\ClassMethod) {
             $result .= "\n    flags: " . $this->indent($this->renderFlags($op));
         }

--- a/test/code/and.test
+++ b/test/code/and.test
@@ -7,6 +7,7 @@ Block#1
         name: LITERAL('a')
         result: Var#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1
         if: Block#2
         else: Block#3

--- a/test/code/foreach.test
+++ b/test/code/foreach.test
@@ -23,6 +23,7 @@ Block#2
         var: Var#2<$a>
         result: Var#4
     Stmt_JumpIf
+        from_loop: true
         cond: Var#4
         if: Block#3
         else: Block#4

--- a/test/code/forever.test
+++ b/test/code/forever.test
@@ -12,6 +12,7 @@ Block#2
     Parent: Block#1
     Parent: Block#3
     Stmt_JumpIf
+        from_loop: true
         cond: LITERAL(true)
         if: Block#3
         else: Block#4

--- a/test/code/if_else.test
+++ b/test/code/if_else.test
@@ -9,6 +9,7 @@ echo "c";
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$a>
         if: Block#2
         else: Block#3

--- a/test/code/if_else_if_else.test
+++ b/test/code/if_else_if_else.test
@@ -11,6 +11,7 @@ echo "d";
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$a>
         if: Block#2
         else: Block#3
@@ -25,6 +26,7 @@ Block#2
 Block#3
     Parent: Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#2<$b>
         if: Block#5
         else: Block#6

--- a/test/code/if_elseif_else.test
+++ b/test/code/if_elseif_else.test
@@ -11,6 +11,7 @@ echo "d";
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$a>
         if: Block#2
         else: Block#3
@@ -25,6 +26,7 @@ Block#2
 Block#3
     Parent: Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#2<$b>
         if: Block#5
         else: Block#6

--- a/test/code/isset.test
+++ b/test/code/isset.test
@@ -11,6 +11,7 @@ Block#1
         vars[2]: Var#3<$c>
         result: Var#4
     Stmt_JumpIf
+        from_loop: false
         cond: Var#4
         if: Block#2
         else: Block#3

--- a/test/code/list.test
+++ b/test/code/list.test
@@ -52,6 +52,7 @@ Block#2
         var: Var#3<$a>
         result: Var#15
     Stmt_JumpIf
+        from_loop: true
         cond: Var#15
         if: Block#3
         else: Block#4

--- a/test/code/namespaced_conditionals.test
+++ b/test/code/namespaced_conditionals.test
@@ -14,6 +14,7 @@ namespace Bar {
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: LITERAL(true)
         if: Block#2
         else: Block#3
@@ -29,6 +30,7 @@ Block#3
     Parent: Block#2
     Parent: Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: LITERAL(false)
         if: Block#4
         else: Block#5

--- a/test/code/nested_phi.test
+++ b/test/code/nested_phi.test
@@ -36,6 +36,7 @@ Block#2
         var: Var#3
         result: Var#6
     Stmt_JumpIf
+        from_loop: true
         cond: Var#6
         if: Block#3
         else: Block#4
@@ -54,6 +55,7 @@ Block#3
         right: LITERAL(0)
         result: Var#10
     Stmt_JumpIf
+        from_loop: false
         cond: Var#10
         if: Block#5
         else: Block#2

--- a/test/code/or.test
+++ b/test/code/or.test
@@ -7,6 +7,7 @@ Block#1
         name: LITERAL('a')
         result: Var#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1
         if: Block#2
         else: Block#3

--- a/test/code/switch2.test
+++ b/test/code/switch2.test
@@ -18,6 +18,7 @@ Block#1
         right: Var#2<$j>
         result: Var#3
     Stmt_JumpIf
+        from_loop: false
         cond: Var#3
         if: Block#2
         else: Block#3
@@ -38,6 +39,7 @@ Block#3
         right: Var#4<$k>
         result: Var#5
     Stmt_JumpIf
+        from_loop: false
         cond: Var#5
         if: Block#2
         else: Block#5
@@ -57,6 +59,7 @@ Block#5
         right: Var#6<$x>
         result: Var#7
     Stmt_JumpIf
+        from_loop: false
         cond: Var#7
         if: Block#4
         else: Block#7
@@ -75,6 +78,7 @@ Block#7
         right: Var#8<$y>
         result: Var#9
     Stmt_JumpIf
+        from_loop: false
         cond: Var#9
         if: Block#8
         else: Block#2

--- a/test/code/ternary.test
+++ b/test/code/ternary.test
@@ -4,6 +4,7 @@ $a = $b ? $c : $d;
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$b>
         if: Block#2
         else: Block#3

--- a/test/code/ternary2.test
+++ b/test/code/ternary2.test
@@ -4,6 +4,7 @@ $a = $b ?: ($b ?: $c);
 -----
 Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$b>
         if: Block#2
         else: Block#3
@@ -20,6 +21,7 @@ Block#2
 Block#3
     Parent: Block#1
     Stmt_JumpIf
+        from_loop: false
         cond: Var#1<$b>
         if: Block#5
         else: Block#6

--- a/test/code/type_assert.test
+++ b/test/code/type_assert.test
@@ -11,6 +11,7 @@ Block#1
         args[0]: Var#1<$a>
         result: Var#2
     Stmt_JumpIf
+        from_loop: false
         cond: Var#2
         if: Block#2
         else: Block#3
@@ -20,6 +21,7 @@ Block#2
     Parent: Block#3
     Var#3 = Phi(LITERAL(true), Var#4)
     Stmt_JumpIf
+        from_loop: false
         cond: Var#3
         if: Block#4
         else: Block#5


### PR DESCRIPTION
when I visit the CFG of this code for instance:
```
// block 1
while(something) { // block 2
    // block 3
}
// block 4
```

block 3 has block 2 as parent and block 2 has block 3 has parent which is correct as well
but still I need to first visit block 2 and then block 3 because it's what happening when executing this PHP code

because we don't have any information in the CFG about loops, the only option I had is to visit the whole CFG a first time to understand where are the loops, it's a bit difficult so I was thinking about adding information about loops in the `jumpif` statements that are generated?
