### PR TITLE
support variable variable names

### DIFF
--- a/lib/PHPCfg/Op/Expr/VarVar.php
+++ b/lib/PHPCfg/Op/Expr/VarVar.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of PHP-CFG, a Control flow graph implementation for PHP
+ *
+ * @copyright 2015 Anthony Ferrara. All rights reserved
+ * @license MIT See LICENSE at the root of the project for more info
+ */
+
+namespace PHPCfg\Op\Expr;
+
+use PHPCfg\Op\Expr;
+use PhpCfg\Operand;
+
+class VarVar extends Expr
+{
+    public Operand $var;
+
+    protected array $writeVariables = ['result'];
+
+    public function __construct(Operand $var, array $attributes = [])
+    {
+        parent::__construct($attributes);
+        $this->var = $this->addReadRef($var);
+    }
+
+    public function getVariableNames(): array
+    {
+        return ['var', 'result'];
+    }
+}

--- a/lib/PHPCfg/Parser.php
+++ b/lib/PHPCfg/Parser.php
@@ -801,16 +801,26 @@ class Parser
             return new Literal($expr->name);
         }
         if ($expr instanceof Node\Expr\Variable) {
-            if ($expr->name === 'this') {
-                return new Operand\BoundVariable(
-                    $this->parseExprNode($expr->name),
-                    false,
-                    Operand\BoundVariable::SCOPE_OBJECT,
-                    $this->currentClass,
-                );
-            }
+            if (is_scalar($expr->name)) {
+                if ($expr->name === 'this') {
+                    return new Operand\BoundVariable(
+                        $this->parseExprNode($expr->name),
+                        false,
+                        Operand\BoundVariable::SCOPE_OBJECT,
+                        $this->currentClass,
+                    );
+                }
 
-            return new Variable($this->parseExprNode($expr->name));
+                return new Variable($this->parseExprNode($expr->name));
+            }
+            
+            // variable variable
+            $this->block->children[] = $op = new Op\Expr\VarVar(
+                $this->readVariable($this->parseExprNode($expr->name)), 
+                $this->mapAttributes($expr)
+            );
+
+            return $op->result;
         }
         if ($expr instanceof Node\Name) {
             $isReserved = in_array(strtolower($expr->getLast()), ['int', 'string', 'array', 'callable', 'float', 'bool'], true);

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -60,17 +60,8 @@ abstract class Printer
             return "LITERAL{$type}(" . var_export($var->value, true) . ')';
         }
         if ($var instanceof Variable) {
-            assert($var->name instanceof Literal || $var->name instanceof Temporary || $var->name instanceof Variable);
+            assert($var->name instanceof Literal);
             $prefix = "{$type}$";
-
-            if ($var->name instanceof Temporary) {
-                return "Var{$type}#" . $this->getVarId($var->name);
-            }
-
-            if ($var->name instanceof Variable) {
-                $id = $this->getVarId($var);
-                return "Var{$type}#{$id}" . '<' . $this->renderOperand($var->name) . '>';
-            }
 
             if ($var instanceof BoundVariable) {
                 if ($var->byRef) {

--- a/lib/PHPCfg/Printer.php
+++ b/lib/PHPCfg/Printer.php
@@ -60,8 +60,18 @@ abstract class Printer
             return "LITERAL{$type}(" . var_export($var->value, true) . ')';
         }
         if ($var instanceof Variable) {
-            assert($var->name instanceof Literal);
+            assert($var->name instanceof Literal || $var->name instanceof Temporary || $var->name instanceof Variable);
             $prefix = "{$type}$";
+
+            if ($var->name instanceof Temporary) {
+                return "Var{$type}#" . $this->getVarId($var->name);
+            }
+
+            if ($var->name instanceof Variable) {
+                $id = $this->getVarId($var);
+                return "Var{$type}#{$id}" . '<' . $this->renderOperand($var->name) . '>';
+            }
+
             if ($var instanceof BoundVariable) {
                 if ($var->byRef) {
                     $prefix = '&$';

--- a/test/code/variablevariable.test
+++ b/test/code/variablevariable.test
@@ -5,63 +5,80 @@ ${$foo1."plus".$foo2} = "bar";
 $$foo = "bar"; 
 $$$$$$$a = "b";
 
-echo $foo->{$baz[1]} . "\n";
-echo $foo->{$start . $end} . "\n";
-echo $foo->{$arr[1]} . "\n";
-echo $foo->{$arr}[1] . "\n";
+echo $foo->{$baz[1]};
+echo $foo->{$start . $end};
+echo $foo->{$arr[1]};
+echo $foo->{$arr}[1];
 -----
 Block#1
-    Expr_Assign
+    Expr_VarVar
         var: Var#1<$foo>
-        expr: LITERAL('bar')
         result: Var#2
-    Expr_BinaryOp_Concat
-        left: Var#3<$foo1>
-        right: LITERAL('plus')
-        result: Var#4
-    Expr_BinaryOp_Concat
-        left: Var#4
-        right: Var#5<$foo2>
-        result: Var#6
     Expr_Assign
-        var: Var#6
+        var: Var#2
         expr: LITERAL('bar')
+        result: Var#3
+    Expr_BinaryOp_Concat
+        left: Var#4<$foo1>
+        right: LITERAL('plus')
+        result: Var#5
+    Expr_BinaryOp_Concat
+        left: Var#5
+        right: Var#6<$foo2>
         result: Var#7
+    Expr_VarVar
+        var: Var#7
+        result: Var#8
     Expr_Assign
-        var: Var#8<$foo>
+        var: Var#8
         expr: LITERAL('bar')
         result: Var#9
+    Expr_VarVar
+        var: Var#1<$foo>
+        result: Var#10
     Expr_Assign
-        var: Var#10<Var#11<Var#12<Var#13<Var#14<Var#15<$a>>>>>>
-        expr: LITERAL('b')
+        var: Var#10
+        expr: LITERAL('bar')
+        result: Var#11
+    Expr_VarVar
+        var: Var#12<$a>
+        result: Var#13
+    Expr_VarVar
+        var: Var#13
+        result: Var#14
+    Expr_VarVar
+        var: Var#14
+        result: Var#15
+    Expr_VarVar
+        var: Var#15
         result: Var#16
-    Expr_ArrayDimFetch
-        var: Var#17<$baz>
-        dim: LITERAL(1)
+    Expr_VarVar
+        var: Var#16
+        result: Var#17
+    Expr_VarVar
+        var: Var#17
         result: Var#18
-    Expr_PropertyFetch
-        var: Var#19<$foo>
-        name: Var#18
-        result: Var#20
-    Expr_BinaryOp_Concat
-        left: Var#20
-        right: LITERAL('
-        ')
+    Expr_Assign
+        var: Var#18
+        expr: LITERAL('b')
+        result: Var#19
+    Expr_ArrayDimFetch
+        var: Var#20<$baz>
+        dim: LITERAL(1)
         result: Var#21
-    Terminal_Echo
-        expr: Var#21
-    Expr_BinaryOp_Concat
-        left: Var#22<$start>
-        right: Var#23<$end>
-        result: Var#24
     Expr_PropertyFetch
-        var: Var#19<$foo>
-        name: Var#24
-        result: Var#25
+        var: Var#1<$foo>
+        name: Var#21
+        result: Var#22
+    Terminal_Echo
+        expr: Var#22
     Expr_BinaryOp_Concat
-        left: Var#25
-        right: LITERAL('
-        ')
+        left: Var#23<$start>
+        right: Var#24<$end>
+        result: Var#25
+    Expr_PropertyFetch
+        var: Var#1<$foo>
+        name: Var#25
         result: Var#26
     Terminal_Echo
         expr: Var#26
@@ -70,29 +87,19 @@ Block#1
         dim: LITERAL(1)
         result: Var#28
     Expr_PropertyFetch
-        var: Var#19<$foo>
+        var: Var#1<$foo>
         name: Var#28
         result: Var#29
-    Expr_BinaryOp_Concat
-        left: Var#29
-        right: LITERAL('
-        ')
-        result: Var#30
     Terminal_Echo
-        expr: Var#30
+        expr: Var#29
     Expr_PropertyFetch
-        var: Var#19<$foo>
+        var: Var#1<$foo>
         name: Var#27<$arr>
-        result: Var#31
+        result: Var#30
     Expr_ArrayDimFetch
-        var: Var#31
+        var: Var#30
         dim: LITERAL(1)
-        result: Var#32
-    Expr_BinaryOp_Concat
-        left: Var#32
-        right: LITERAL('
-        ')
-        result: Var#33
+        result: Var#31
     Terminal_Echo
-        expr: Var#33
+        expr: Var#31
     Terminal_Return

--- a/test/code/variablevariable.test
+++ b/test/code/variablevariable.test
@@ -1,0 +1,98 @@
+<?php
+
+${$foo} = "bar";
+${$foo1."plus".$foo2} = "bar";
+$$foo = "bar"; 
+$$$$$$$a = "b";
+
+echo $foo->{$baz[1]} . "\n";
+echo $foo->{$start . $end} . "\n";
+echo $foo->{$arr[1]} . "\n";
+echo $foo->{$arr}[1] . "\n";
+-----
+Block#1
+    Expr_Assign
+        var: Var#1<$foo>
+        expr: LITERAL('bar')
+        result: Var#2
+    Expr_BinaryOp_Concat
+        left: Var#3<$foo1>
+        right: LITERAL('plus')
+        result: Var#4
+    Expr_BinaryOp_Concat
+        left: Var#4
+        right: Var#5<$foo2>
+        result: Var#6
+    Expr_Assign
+        var: Var#6
+        expr: LITERAL('bar')
+        result: Var#7
+    Expr_Assign
+        var: Var#8<$foo>
+        expr: LITERAL('bar')
+        result: Var#9
+    Expr_Assign
+        var: Var#10<Var#11<Var#12<Var#13<Var#14<Var#15<$a>>>>>>
+        expr: LITERAL('b')
+        result: Var#16
+    Expr_ArrayDimFetch
+        var: Var#17<$baz>
+        dim: LITERAL(1)
+        result: Var#18
+    Expr_PropertyFetch
+        var: Var#19<$foo>
+        name: Var#18
+        result: Var#20
+    Expr_BinaryOp_Concat
+        left: Var#20
+        right: LITERAL('
+        ')
+        result: Var#21
+    Terminal_Echo
+        expr: Var#21
+    Expr_BinaryOp_Concat
+        left: Var#22<$start>
+        right: Var#23<$end>
+        result: Var#24
+    Expr_PropertyFetch
+        var: Var#19<$foo>
+        name: Var#24
+        result: Var#25
+    Expr_BinaryOp_Concat
+        left: Var#25
+        right: LITERAL('
+        ')
+        result: Var#26
+    Terminal_Echo
+        expr: Var#26
+    Expr_ArrayDimFetch
+        var: Var#27<$arr>
+        dim: LITERAL(1)
+        result: Var#28
+    Expr_PropertyFetch
+        var: Var#19<$foo>
+        name: Var#28
+        result: Var#29
+    Expr_BinaryOp_Concat
+        left: Var#29
+        right: LITERAL('
+        ')
+        result: Var#30
+    Terminal_Echo
+        expr: Var#30
+    Expr_PropertyFetch
+        var: Var#19<$foo>
+        name: Var#27<$arr>
+        result: Var#31
+    Expr_ArrayDimFetch
+        var: Var#31
+        dim: LITERAL(1)
+        result: Var#32
+    Expr_BinaryOp_Concat
+        left: Var#32
+        right: LITERAL('
+        ')
+        result: Var#33
+    Terminal_Echo
+        expr: Var#33
+    Terminal_Return


### PR DESCRIPTION
currently php-cfg produces an error when it encounters a variable variable name bacause of line 63:
`assert($var->name instanceof Literal);`