### PR TITLE
php 8.0 is required

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "7.4"
           - "8.0"
           - "8.1"
           - "8.2"

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         }
     ],
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "nikic/php-parser": "^5.0",
         "phpdocumentor/graphviz": "^1.0.4"
     },


### PR DESCRIPTION
because of `mixed` built-in type used here:

https://github.com/ircmaxell/php-cfg/blob/master/lib/PHPCfg/Op.php#L40

we should probably update the minimum php version required to 8.0.